### PR TITLE
Updates syntax for checking if user is CMS Admin

### DIFF
--- a/velocity-reference.md
+++ b/velocity-reference.md
@@ -922,7 +922,7 @@ com.dotmarketing.session_host
 ## &nbsp;
 ### Is user "admin"?
 ```
-#set ($userIsAdmin = $user.isCMSAdmin()) ## True | False
+#set ($userIsAdmin = $cmsuser.isCMSAdmin($user)) ## True | False
 ```
 
 ## &nbsp;


### PR DESCRIPTION
Changing syntax for `isCMSAdmin()`. Current syntax didn't work for me, but found [this](https://github.com/dotCMS/core/blob/master/dotCMS/src/main/java/com/dotcms/rendering/velocity/viewtools/CMSUsersWebAPI.java#L228) working syntax.